### PR TITLE
Change name to abstract type and remove semi-resizable type

### DIFF
--- a/src/WeightVectors.jl
+++ b/src/WeightVectors.jl
@@ -19,7 +19,7 @@ abstract type AbstractWeightVector <: AbstractVector{Float64} end
 """
     FixedSizeWeightVector <: AbstractWeightVector
 
-An object that confomrs the the `Weights` interface and cannot be resized.
+An object that conforms to the `AbstractWeightVector` interface and cannot be resized.
 """
 struct FixedSizeWeightVector <: AbstractWeightVector
     m::Memory{UInt64}
@@ -29,7 +29,7 @@ end
 """
     WeightVector <: AbstractWeightVector
 
-An object that confomrs the the `Weights` interface and can be resized.
+An object that conforms to the `AbstractWeightVector` interface and can be resized.
 """
 mutable struct WeightVector <: AbstractWeightVector
     m::Memory{UInt64}
@@ -796,9 +796,9 @@ end
 Base.size(w::AbstractWeightVector) = (w.m[1],)
 
 FixedSizeWeightVector(len::Integer) = _FixedSizeWeightVector(initialize_empty(Int(len)))
-FixedSizeWeightVector(x::Weights) = _FixedSizeWeightVector(copy(x.m))
+FixedSizeWeightVector(x::AbstractWeightVector) = _FixedSizeWeightVector(copy(x.m))
 WeightVector(len::Integer) = _WeightVector(initialize_empty(Int(len)))
-WeightVector(x::Weights) = _WeightVector(copy(x.m))
+WeightVector(x::AbstractWeightVector) = _WeightVector(copy(x.m))
 
 # TODO: this can be significantly optimized
 function (::Type{T})(x) where {T <: AbstractWeightVector}

--- a/src/WeightVectors.jl
+++ b/src/WeightVectors.jl
@@ -1,6 +1,6 @@
 module WeightVectors
 
-export AbstractWeightVector, FixedSizeWeightVector, WeightVector
+export FixedSizeWeightVector, WeightVector
 
 using Random
 

--- a/src/WeightVectors.jl
+++ b/src/WeightVectors.jl
@@ -1,6 +1,5 @@
 module WeightVectors
 
-VERSION >= v"1.11.0-DEV.469" && eval(Meta.parse("public Weights"))
 export AbstractWeightVector, FixedSizeWeightVector, WeightVector
 
 using Random

--- a/src/WeightVectors.jl
+++ b/src/WeightVectors.jl
@@ -1,7 +1,7 @@
 module WeightVectors
 
 VERSION >= v"1.11.0-DEV.469" && eval(Meta.parse("public Weights"))
-export FixedSizeWeightVector, WeightVector, SemiResizableWeightVector
+export AbstractWeightVector, FixedSizeWeightVector, WeightVector
 
 using Random
 
@@ -11,41 +11,31 @@ const DEBUG = Base.JLOptions().check_bounds == 1
 _convert(T, x) = DEBUG ? T(x) : x%T
 
 """
-    Weights <: AbstractVector{Float64}
+    AbstractWeightVector <: AbstractVector{Float64}
 
 An abstract vector capable of storing normal, non-negative floating point numbers on which
 `rand` samples an index according to values rather than sampling a value uniformly.
 """
 abstract type Weights <: AbstractVector{Float64} end
 """
-    FixedSizeWeightVector <: Weights
+    FixedSizeWeightVector <: AbstractWeightVector
 
 An object that confomrs the the `Weights` interface and cannot be resized.
 """
-struct FixedSizeWeightVector <: Weights
+struct FixedSizeWeightVector <: AbstractWeightVector
     m::Memory{UInt64}
     global _FixedSizeWeightVector
     _FixedSizeWeightVector(m::Memory{UInt64}) = new(m)
     FixedSizeWeightVector(len::Integer) = new(initialize_empty(Int(len)))
 end
 """
-    WeightVector <: Weights
+    WeightVector <: AbstractWeightVector
 
 An object that confomrs the the `Weights` interface and can be resized.
 """
-mutable struct WeightVector <: Weights
+mutable struct WeightVector <: AbstractWeightVector
     m::Memory{UInt64}
     WeightVector(len::Integer) = new(initialize_empty(Int(len)))
-end
-"""
-    SemiResizableWeightVector <: Weights
-
-An object that confomrs the the `Weights` interface and can be resized, but only to sizes
-at most as large as it's original size.
-"""
-struct SemiResizableWeightVector <: Weights
-    m::Memory{UInt64}
-    SemiResizableWeightVector(len::Integer) = new(initialize_empty(Int(len)))
 end
 
 #===== Overview  ======
@@ -180,12 +170,12 @@ TODO
 # Trivial extensions:
 # push!, delete!
 
-Random.rand(rng::AbstractRNG, st::Random.SamplerTrivial{<:Weights}) = _rand(rng, st[].m)
-Random.Sampler(::Type{<:Random.AbstractRNG}, w::Weights, ::Random.Repetition) = Random.SamplerTrivial(w)
-Random.gentype(::Type{<:Weights}) = Int
-Base.getindex(w::Weights, i::Int) = _getindex(w.m, i)
-Base.setindex!(w::Weights, v, i::Int) = (_setindex!(w.m, Float64(v), i); w)
-Base.iszero(w::Weights) = w.m[2] == 5
+Random.rand(rng::AbstractRNG, st::Random.SamplerTrivial{<:AbstractWeightVector}) = _rand(rng, st[].m)
+Random.Sampler(::Type{<:Random.AbstractRNG}, w::AbstractWeightVector, ::Random.Repetition) = Random.SamplerTrivial(w)
+Random.gentype(::Type{<:AbstractWeightVector}) = Int
+Base.getindex(w::AbstractWeightVector, i::Int) = _getindex(w.m, i)
+Base.setindex!(w::AbstractWeightVector, v, i::Int) = (_setindex!(w.m, Float64(v), i); w)
+Base.iszero(w::AbstractWeightVector) = w.m[2] == 5
 
 #=@inbounds=# function _rand(rng::AbstractRNG, m::Memory{UInt64})
 
@@ -697,14 +687,13 @@ end
 allocated_memory(length::Int) = 10794 + 8*length
 length_from_memory(allocated_memory::Int) = Int((allocated_memory-10794)/8)
 
-Base.resize!(w::Union{SemiResizableWeightVector, WeightVector}, len::Integer) = resize!(w, Int(len))
-function Base.resize!(w::Union{SemiResizableWeightVector, WeightVector}, len::Int)
+Base.resize!(w::WeightVector, len::Integer) = resize!(w, Int(len))
+function Base.resize!(w::WeightVector, len::Int)
     m = w.m
     old_len = m[1]
     if len > old_len
         am = allocated_memory(len)
         if am > length(m)
-            w isa SemiResizableWeightVector && throw(ArgumentError("Cannot increase the size of a SemiResizableWeightVector above its original allocated size. Try using a WeightVector instead."))
             _resize!(w, len)
         else
             m[1] = len
@@ -805,10 +794,10 @@ function compact!(dst::Memory{UInt64}, src::Memory{UInt64})
 end
 
 # Conform to the AbstractArray API
-Base.size(w::Weights) = (w.m[1],)
+Base.size(w::AbstractWeightVector) = (w.m[1],)
 
 # Define convinience constructors TODO: these can be significantly optimized, especially when `x isa Weights`
-function (::Type{T})(x::AbstractVector{<:Real}) where {T <: Weights}
+function (::Type{T})(x::AbstractVector{<:Real}) where {T <: AbstractWeightVector}
     w = T(length(x))
     for (i, v) in enumerate(x)
         w[i] = v

--- a/src/WeightVectors.jl
+++ b/src/WeightVectors.jl
@@ -16,7 +16,7 @@ _convert(T, x) = DEBUG ? T(x) : x%T
 An abstract vector capable of storing normal, non-negative floating point numbers on which
 `rand` samples an index according to values rather than sampling a value uniformly.
 """
-abstract type Weights <: AbstractVector{Float64} end
+abstract type AbstractWeightVector <: AbstractVector{Float64} end
 """
     FixedSizeWeightVector <: AbstractWeightVector
 

--- a/src/bulk_sampling.jl
+++ b/src/bulk_sampling.jl
@@ -1,7 +1,7 @@
 
 using AliasTables
 
-Random.rand!(rng::AbstractRNG, A::AbstractArray, st::Random.SamplerTrivial{<:Weights}) = _rand!(rng, A, st[].m)
+Random.rand!(rng::AbstractRNG, A::AbstractArray, st::Random.SamplerTrivial{<:AbstractWeightVector}) = _rand!(rng, A, st[].m)
 
 function _rand!(rng::AbstractRNG, samples::AbstractArray, m::Memory{UInt64})
     n = length(samples)

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -2,7 +2,6 @@ using WeightVectors, Test
 
 @test WeightVectors.FixedSizeWeightVector(10) isa WeightVectors.FixedSizeWeightVector
 @test WeightVectors.WeightVector(10) isa WeightVectors.WeightVector
-@test WeightVectors.SemiResizableWeightVector(10) isa WeightVectors.SemiResizableWeightVector
 
 w = WeightVectors.FixedSizeWeightVector(10)
 
@@ -226,7 +225,7 @@ verify(w.m)
 w = WeightVectors.FixedSizeWeightVector(10)
 @test_throws MethodError resize!(w, 20)
 @test_throws MethodError resize!(w, 5)
-w2 = WeightVectors.SemiResizableWeightVector(w)
+w2 = WeightVectors.ResizableWeightVector(w)
 resize!(w2, 5)
 @test length(w2) == 5
 @test length(w) == 10 # The fixed size has not changed

--- a/test/weights.jl
+++ b/test/weights.jl
@@ -225,7 +225,7 @@ verify(w.m)
 w = WeightVectors.FixedSizeWeightVector(10)
 @test_throws MethodError resize!(w, 20)
 @test_throws MethodError resize!(w, 5)
-w2 = WeightVectors.ResizableWeightVector(w)
+w2 = WeightVectors.WeightVector(w)
 resize!(w2, 5)
 @test length(w2) == 5
 @test length(w) == 10 # The fixed size has not changed


### PR DESCRIPTION
This PR does two things:

- Remove `SemiResizableWeightVector` as discussed;
- Change `Weights` to `AbstractWeightVector` and export it.